### PR TITLE
docs: fix typo in install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ npm install simple-signal-server
 ```
 
 Client (without Browserify):
-```
-<script src="simple-signal-client.js></script>
+```html
+<script src="simple-signal-client.js"></script>
 ```
 
 ## Usage


### PR DESCRIPTION
Adds a missing closing quote to the install example. Also adds syntax highlighting to that code block.

😁 