### PR TITLE
Update cuid to version which works

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "dependencies": {
     "babel-polyfill": "^6.23.0",
-    "cuid": "^1.3.8",
+    "cuid": "^2.0.2",
     "simple-peer": "^6.4.1"
   },
   "scripts": {


### PR DESCRIPTION
The version of cuid used previously doesn't work on modern browsers. Updating the dependency doesn't seem to break anything.